### PR TITLE
Minor fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "mgp25/instagram-php": "^4.0",
+        "adrifkat/instagram-api": "*",
         "react/child-process": "0.5.2"
     }
 }

--- a/goLive.php
+++ b/goLive.php
@@ -43,12 +43,12 @@ try {
     $stream = $ig->live->create();
     $broadcastId = $stream->getBroadcastId();
     $ig->live->start($broadcastId);
-    // Switch from RTMPS to RTMP upload URL, since RTMPS doesn't work well.
-    $streamUploadUrl = preg_replace(
+    // Switch from RTMPS to RTMP upload URL, since RTMPS doesn't work well. "no need to switch it port 80 not working"
+    /*$streamUploadUrl = preg_replace(
         '#^rtmps://([^/]+?):443/#ui',
         'rtmp://\1:80/',
         $stream->getUploadUrl()
-    );
+    );*/
 
     //Grab the stream url as well as the stream key.
     $split = preg_split("[".$broadcastId."]", $streamUploadUrl);


### PR DESCRIPTION
the older instagram private API has been removed due to DMCA takedown. replaced with a copy of it. Also the regex to replace the rtmps to rtmp is useless as rtmp is not working anymore.